### PR TITLE
Prevent statistical analyses if too few individuals are present in the subset

### DIFF
--- a/R/boundedMeanDP.R
+++ b/R/boundedMeanDP.R
@@ -16,7 +16,7 @@ boundedMeanDP <- function(input_data, epsilon, lower_bound, upper_bound){
   minRowsDP <- as.numeric(getOption("dsPrivacy.minRowsDP", default=0))
 
   if(length < minRowsDP){
-    return(list(Mean=NA, Ntotal=NA, ErrorMsg="ERROR: not enough rows to use DP"))
+    return(list(Mean=NA, Ntotal=NA, ErrorMsg="ERROR: you can't run boundedMeanDP on a subset of less than dsPrivacy.minRowsDP elements"))
   }
 
   mean <- py_module$pydp_wrapper$mean_PyDP$pyDP_bounded_mean(input_data, epsilon / 2, lower_bound, upper_bound)

--- a/R/boundedMeanDP.R
+++ b/R/boundedMeanDP.R
@@ -13,7 +13,7 @@
 boundedMeanDP <- function(input_data, epsilon, lower_bound, upper_bound){
   length <- py_module$pydp_wrapper$count_PyDP$pyDP_count(input_data, epsilon / 2)
 
-  minRowsDP <- as.numeric(getOption("dsPrivacy.minRowsDP"))
+  minRowsDP <- as.numeric(getOption("dsPrivacy.minRowsDP", default=0))
 
   if(length < minRowsDP){
     return(list(Mean=NA, Ntotal=NA, ErrorMsg="ERROR: not enough rows to use DP"))
@@ -21,5 +21,5 @@ boundedMeanDP <- function(input_data, epsilon, lower_bound, upper_bound){
 
   mean <- py_module$pydp_wrapper$mean_PyDP$pyDP_bounded_mean(input_data, epsilon / 2, lower_bound, upper_bound)
 
-  return(list(Mean=mean, Ntotal=length))
+  return(list(Mean=mean, Ntotal=length, ErrorMsg=NA))
 }

--- a/R/boundedMeanDP.R
+++ b/R/boundedMeanDP.R
@@ -10,9 +10,16 @@
 #' @export
 
 
-boundedMeanDP <- function(input_data, epsilon, lower_bound, upper_bound) {
-  mean <- py_module$pydp_wrapper$mean_PyDP$pyDP_bounded_mean(input_data, epsilon / 2, lower_bound, upper_bound)
+boundedMeanDP <- function(input_data, epsilon, lower_bound, upper_bound){
   length <- py_module$pydp_wrapper$count_PyDP$pyDP_count(input_data, epsilon / 2)
 
-  return(list(Mean = mean, Ntotal = length))
+  minRowsDP <- as.numeric(getOption("dsPrivacy.minRowsDP"))
+
+  if(length < minRowsDP){
+    return(list(Mean=NA, Ntotal=NA, ErrorMsg="ERROR: not enough rows to use DP"))
+  }
+
+  mean <- py_module$pydp_wrapper$mean_PyDP$pyDP_bounded_mean(input_data, epsilon / 2, lower_bound, upper_bound)
+
+  return(list(Mean=mean, Ntotal=length))
 }


### PR DESCRIPTION
## Description

Prevent statistical analyses if too few individuals are present in the subset.

The option `dsPrivacy.minRowsDP` can be set in Opal's UI.

Fix #18 